### PR TITLE
-Add Gesture[Left|Right]Idx to emulation.

### DIFF
--- a/Runtime/Scripts/AASEmulatorRuntime.cs
+++ b/Runtime/Scripts/AASEmulatorRuntime.cs
@@ -557,6 +557,8 @@ namespace NAK.AASEmulator.Runtime
         {
             AnimatorManager.SetCoreParameter("GestureLeft", _gestureLeft);
             AnimatorManager.SetCoreParameter("GestureRight", _gestureRight);
+            AnimatorManager.SetCoreParameter("GestureLeftIdx", _gestureLeftIdx);
+            AnimatorManager.SetCoreParameter("GestureRightIdx", _gestureRightIdx);
             AnimatorManager.SetCoreParameter("Grounded", Grounded);
             AnimatorManager.SetCoreParameter("Crouching", Crouching);
             AnimatorManager.SetCoreParameter("Prone", Prone);

--- a/Runtime/Scripts/AASEmulatorRuntime.cs
+++ b/Runtime/Scripts/AASEmulatorRuntime.cs
@@ -557,8 +557,8 @@ namespace NAK.AASEmulator.Runtime
         {
             AnimatorManager.SetCoreParameter("GestureLeft", _gestureLeft);
             AnimatorManager.SetCoreParameter("GestureRight", _gestureRight);
-            AnimatorManager.SetCoreParameter("GestureLeftIdx", _gestureLeftIdx);
-            AnimatorManager.SetCoreParameter("GestureRightIdx", _gestureRightIdx);
+            AnimatorManager.SetCoreParameter("GestureLeftIdx", _gestureLeftIdx -1);
+            AnimatorManager.SetCoreParameter("GestureRightIdx", _gestureRightIdx -1);
             AnimatorManager.SetCoreParameter("Grounded", Grounded);
             AnimatorManager.SetCoreParameter("Crouching", Crouching);
             AnimatorManager.SetCoreParameter("Prone", Prone);

--- a/Runtime/Scripts/SubSystems/AnimatorManager.cs
+++ b/Runtime/Scripts/SubSystems/AnimatorManager.cs
@@ -25,6 +25,9 @@ namespace NAK.AASEmulator.Runtime.SubSystems
             { "MovementY", AnimatorControllerParameterType.Float },
             { "Toggle", AnimatorControllerParameterType.Float },
             { "Emote", AnimatorControllerParameterType.Float },
+            // Ints
+            { "GestureLeftIdx", AnimatorControllerParameterType.Int },
+            { "GestureRightIdx", AnimatorControllerParameterType.Int },
             // Bools
             { "Grounded", AnimatorControllerParameterType.Bool },
             { "Crouching", AnimatorControllerParameterType.Bool },


### PR DESCRIPTION
Tested in Runtime, looks ok, but I am unsure if it's exactly what the values should be doing.
I also did it kinda jank by editing Apply_CoreParameters() but you know better than me.

GestureLeft to GestureLeftIdx table:
-1 to -1
-0.5 to -1
0 to 0
0.5 to 1
1 to 1
2 to 2
3 to 3
4 to 4
5 to 5
6 to 6